### PR TITLE
[RFC] Transactions

### DIFF
--- a/ALPM.xs
+++ b/ALPM.xs
@@ -146,7 +146,7 @@ check_conflicts(self, ...)
 	STACK2LIST(i, L, p2c_pkg);
 	L = clist = alpm_checkconflicts(self, L);
 	LIST2STACK(clist, c2p_conflict);
-	ZAPLIST(L, freeconflict);
+	ZAPLIST(L, alpm_conflict_free);
 
 SV *
 fetch_pkgurl(self, url)

--- a/ALPM.xs
+++ b/ALPM.xs
@@ -7,8 +7,9 @@
 #include "types.h"
 #include "cb.h"
 
-#define alpm_croak(HND)\
-	croak("ALPM Error: %s", alpm_strerror(alpm_errno(HND)));
+#include "exception.h"
+
+#define alpm_hthrow(HND) alpm_throw(alpm_errno(HND));
 
 MODULE = ALPM	PACKAGE = ALPM
 
@@ -46,7 +47,7 @@ new(class, root, dbpath)
  CODE:
 	h = alpm_initialize(root, dbpath, &err);
 	if(h == NULL){
-		croak("ALPM Error: %s", alpm_strerror(err));
+		alpm_throw(err);
 	}
 	RETVAL = h;
  OUTPUT:
@@ -223,5 +224,7 @@ INCLUDE: xs/Package.xs
 INCLUDE: xs/DB.xs
 
 # INCLUDE: xs/Transaction.xs
+
+INCLUDE: xs/Exception.xs
 
 # EOF

--- a/ALPM.xs
+++ b/ALPM.xs
@@ -56,14 +56,9 @@ new(class, root, dbpath)
 void
 DESTROY(self)
 	ALPM_Handle self;
- PREINIT:
-	int ret;
  CODE:
-	ret = alpm_release(self);
-	if(ret == -1){
-		croak("ALPM Error: failed to release ALPM handle");
-	}
-	# errno is only inside a handle, which was just released...
+	alpm_trans_release(self);
+	alpm_release(self);
 
 void
 caps(class)

--- a/ALPM.xs
+++ b/ALPM.xs
@@ -218,7 +218,7 @@ INCLUDE: xs/Package.xs
 
 INCLUDE: xs/DB.xs
 
-# INCLUDE: xs/Transaction.xs
+INCLUDE: xs/Transaction.xs
 
 INCLUDE: xs/Exception.xs
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ unless(DynaLoader::dl_findfile('-lalpm')){
 
 sub MY::postamble {
     return <<'END_MAKE';
-ALPM.xs: xs/DB.xs xs/Package.xs xs/Options.xs
+ALPM.xs: xs/DB.xs xs/Package.xs xs/Options.xs xs/Exception.xs
 END_MAKE
 }
 
@@ -25,6 +25,6 @@ WriteMakefile(
 	'LIBS' => [ '-lalpm' ],
 	'META_MERGE' => \%meta,
 	'clean' => { 'FILES' => 't/root t/repos/share const-*.inc' },
-	'OBJECT' => 'ALPM.o types.o cb.o',
+	'OBJECT' => 'ALPM.o types.o cb.o exception.o',
 	'XS' => { 'ALPM.xs' => 'ALPM.c' },
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ unless(DynaLoader::dl_findfile('-lalpm')){
 
 sub MY::postamble {
     return <<'END_MAKE';
-ALPM.xs: xs/DB.xs xs/Package.xs xs/Options.xs xs/Exception.xs
+ALPM.xs: xs/DB.xs xs/Package.xs xs/Options.xs xs/Exception.xs xs/Transaction.xs
 END_MAKE
 }
 

--- a/exception.c
+++ b/exception.c
@@ -1,0 +1,106 @@
+#include <stdlib.h>
+#include <string.h>
+#include <alpm.h>
+
+/* Perl API headers. */
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+#include "ppport.h"
+
+#include <alpm.h>
+
+#include "exception.h"
+
+struct {
+    alpm_errno_t err;
+    char *pclass;
+} emap[] = {
+    { ALPM_ERR_BADPERMS, "ALPM::Exception::BadPerms" },
+    { ALPM_ERR_CONFLICTING_DEPS, "ALPM::Exception::ConflictingDependencies" },
+    { ALPM_ERR_DB_CREATE, "ALPM::Exception::DatabaseCreate" },
+    { ALPM_ERR_DB_INVALID, "ALPM::Exception::DatabaseInvalid" },
+    { ALPM_ERR_DB_INVALID_SIG, "ALPM::Exception::DatabaseInvalidSignature" },
+    { ALPM_ERR_DB_NOT_FOUND, "ALPM::Exception::DatabaseNotFound" },
+    { ALPM_ERR_DB_NOT_NULL, "ALPM::Exception::DatabaseNotNull" },
+    { ALPM_ERR_DB_NULL, "ALPM::Exception::DatabaseNull" },
+    { ALPM_ERR_DB_OPEN, "ALPM::Exception::DatabaseOpen" },
+    { ALPM_ERR_DB_REMOVE, "ALPM::Exception::DatabaseRemove" },
+    { ALPM_ERR_DB_VERSION, "ALPM::Exception::DatabaseVersion" },
+    { ALPM_ERR_DB_WRITE, "ALPM::Exception::DatabaseWrite" },
+    { ALPM_ERR_DLT_INVALID, "ALPM::Exception::DeltaInvalid" },
+    { ALPM_ERR_DLT_PATCHFAILED, "ALPM::Exception::DeltaPatchFailed" },
+    { ALPM_ERR_DISK_SPACE, "ALPM::Exception::DiskSpace" },
+    { ALPM_ERR_EXTERNAL_DOWNLOAD, "ALPM::Exception::ExternalDownload" },
+    { ALPM_ERR_FILE_CONFLICTS, "ALPM::Exception::FileConflicts" },
+    { ALPM_ERR_GPGME, "ALPM::Exception::GPGME" },
+    { ALPM_ERR_HANDLE_LOCK, "ALPM::Exception::HandleLock" },
+    { ALPM_ERR_HANDLE_NOT_NULL, "ALPM::Exception::HandleNotNull" },
+    { ALPM_ERR_HANDLE_NULL, "ALPM::Exception::HandleNull" },
+    { ALPM_ERR_INVALID_REGEX, "ALPM::Exception::InvalidRegex" },
+    { ALPM_ERR_LIBARCHIVE, "ALPM::Exception::LibArchive" },
+    { ALPM_ERR_LIBCURL, "ALPM::Exception::LibCurl" },
+    { ALPM_ERR_MEMORY, "ALPM::Exception::Memory" },
+    { ALPM_ERR_NOT_A_DIR, "ALPM::Exception::NotADirectory" },
+    { ALPM_ERR_NOT_A_FILE, "ALPM::Exception::NotAFile" },
+    { ALPM_ERR_PKG_CANT_REMOVE, "ALPM::Exception::PackageCantRemove" },
+    { ALPM_ERR_PKG_IGNORED, "ALPM::Exception::PackageIgnored" },
+    { ALPM_ERR_PKG_INVALID, "ALPM::Exception::PackageInvalid" },
+    { ALPM_ERR_PKG_INVALID_ARCH, "ALPM::Exception::PackageInvalidArchitecture" },
+    { ALPM_ERR_PKG_INVALID_CHECKSUM, "ALPM::Exception::PackageInvalidChecksum" },
+    { ALPM_ERR_PKG_INVALID_NAME, "ALPM::Exception::PackageInvalidName" },
+    { ALPM_ERR_PKG_INVALID_SIG, "ALPM::Exception::PackageInvalidSignature" },
+    { ALPM_ERR_PKG_MISSING_SIG, "ALPM::Exception::PackageMissingSignature" },
+    { ALPM_ERR_PKG_NOT_FOUND, "ALPM::Exception::PackageNotFound" },
+    { ALPM_ERR_PKG_OPEN, "ALPM::Exception::PackageOpen" },
+    { ALPM_ERR_PKG_REPO_NOT_FOUND, "ALPM::Exception::PackageRepoNotFound" },
+    { ALPM_ERR_RETRIEVE, "ALPM::Exception::Retrieve" },
+    { ALPM_ERR_SERVER_BAD_URL, "ALPM::Exception::ServerBadURL" },
+    { ALPM_ERR_SERVER_NONE, "ALPM::Exception::ServerNone" },
+    { ALPM_ERR_SIG_INVALID, "ALPM::Exception::SignatureInvalid" },
+    { ALPM_ERR_SIG_MISSING, "ALPM::Exception::SignatureMissing" },
+    { ALPM_ERR_SYSTEM, "ALPM::Exception::System" },
+    { ALPM_ERR_TRANS_ABORT, "ALPM::Exception::TransactionAborted" },
+    { ALPM_ERR_TRANS_DUP_TARGET, "ALPM::Exception::TransactionDuplicateTarget" },
+    { ALPM_ERR_TRANS_NOT_INITIALIZED, "ALPM::Exception::TransactionNotInitialized" },
+    { ALPM_ERR_TRANS_NOT_LOCKED, "ALPM::Exception::TransactionNotLocked" },
+    { ALPM_ERR_TRANS_NOT_NULL, "ALPM::Exception::TransactionNotNull" },
+    { ALPM_ERR_TRANS_NOT_PREPARED, "ALPM::Exception::TransactionNotPrepared" },
+    { ALPM_ERR_TRANS_NULL, "ALPM::Exception::TransactionNull" },
+    { ALPM_ERR_TRANS_TYPE, "ALPM::Exception::TransactionType" },
+    { ALPM_ERR_UNSATISFIED_DEPS, "ALPM::Exception::UnsatisfiedDependencies" },
+    { ALPM_ERR_WRONG_ARGS, "ALPM::Exception::WrongArgs" },
+};
+
+const char *
+lookup_eclass(alpm_errno_t err)
+{
+    int i;
+    for(i = 0; i < sizeof(emap) / sizeof(*emap); i++) {
+        if(emap[i].err == err) {
+            return emap[i].pclass;
+        }
+    }
+    return "ALPM::Exception";
+}
+
+void
+alpm_throw(alpm_errno_t err)
+{
+    SV *e = newRV_noinc((SV*) newHV());
+    croak_sv(sv_bless(e, gv_stashpv(lookup_eclass(err), GV_ADD)));
+}
+
+void
+register_eclasses(void)
+{
+    int i;
+    char vname[50];
+    for(i = 0; i < sizeof(emap) / sizeof(*emap); i++) {
+        sprintf(vname, "%s::ISA", emap[i].pclass);
+        av_push(get_av(vname, GV_ADD), newSVpv("ALPM::Exception", 0));
+        sprintf(vname, "%s::errno", emap[i].pclass);
+        /* no idea why we can't just sv_setiv here */
+        sv_setsv(get_sv(vname, GV_ADD), sv_2mortal(newSViv(emap[i].err)));
+    }
+}

--- a/exception.h
+++ b/exception.h
@@ -1,0 +1,8 @@
+#ifndef ALPM_EXCEPTION_H
+#define ALPM_EXCEPTION_H
+
+const char * lookup_eclass(alpm_errno_t err);
+void alpm_throw(alpm_errno_t err);
+void register_eclasses(void);
+
+#endif

--- a/lib/ALPM.pm
+++ b/lib/ALPM.pm
@@ -7,6 +7,7 @@ use ALPM::Dependency;
 use ALPM::Exception;
 use ALPM::File;
 use ALPM::FileList;
+use ALPM::MissingDependency;
 
 our $VERSION;
 BEGIN {

--- a/lib/ALPM.pm
+++ b/lib/ALPM.pm
@@ -4,6 +4,7 @@ use strict;
 
 use ALPM::Conflict;
 use ALPM::Dependency;
+use ALPM::Exception;
 use ALPM::File;
 use ALPM::FileList;
 

--- a/lib/ALPM.pm
+++ b/lib/ALPM.pm
@@ -2,6 +2,11 @@ package ALPM;
 use warnings;
 use strict;
 
+use ALPM::Conflict;
+use ALPM::Dependency;
+use ALPM::File;
+use ALPM::FileList;
+
 our $VERSION;
 BEGIN {
 	$VERSION = '3.05';

--- a/lib/ALPM.pm
+++ b/lib/ALPM.pm
@@ -6,6 +6,7 @@ use ALPM::Conflict;
 use ALPM::Dependency;
 use ALPM::Exception;
 use ALPM::File;
+use ALPM::FileConflict;
 use ALPM::FileList;
 use ALPM::MissingDependency;
 

--- a/lib/ALPM/Conflict.pm
+++ b/lib/ALPM/Conflict.pm
@@ -1,0 +1,12 @@
+package ALPM::Conflict v1.0.0;
+
+use strict;
+use warnings;
+
+sub package1 { return $_[0]->{package1}; }
+
+sub package2 { return $_[0]->{package2}; }
+
+sub reason { return $_[0]->{reason}; }
+
+1;

--- a/lib/ALPM/Dependency.pm
+++ b/lib/ALPM/Dependency.pm
@@ -1,0 +1,12 @@
+package ALPM::Dependency v1.0.0;
+
+use strict;
+use warnings;
+
+sub name { return $_[0]->{name}; }
+
+sub version { return $_[0]->{version}; }
+
+sub mod { return $_[0]->{mod}; }
+
+1;

--- a/lib/ALPM/Exception.pm
+++ b/lib/ALPM/Exception.pm
@@ -1,0 +1,55 @@
+package ALPM::Exception v0.0.1;
+
+use strict;
+use warnings;
+
+use ALPM;
+
+use overload q{""} => sub { sprintf( "ALPM Error: %s.\n", $_[0]->strerror ); };
+
+sub new {
+    my ( $class, %args ) = @_;
+    return bless \%args, $class;
+}
+
+sub throw {
+    my ($self, @args) = @_;
+    die ref $self ? $self : $self->new(@args);
+}
+
+sub strerror { return ALPM::Exception::alpm_strerror($_[0]->errno); }
+
+1;
+
+__END__
+
+=head1 NAME
+
+ALPM::Exception - base class for ALPM exceptions
+
+=head1 SYNOPSIS
+
+ ALPM::Exception->throw();
+
+=head1 DESCRIPTION
+
+=head2 Methods
+
+All of the following methods may be called as either class or instance methods.
+
+=over
+
+=item throw
+
+Throws the exception.
+
+=item errno
+
+If the exception represents one of libalpm's built-in errors C<errno> returns
+the corresponding C<alpm_errno_t>.  Otherwise C<undef> is returned.
+
+=item strerror
+
+Returns the raw libalpm error string.
+
+=back

--- a/lib/ALPM/File.pm
+++ b/lib/ALPM/File.pm
@@ -1,0 +1,12 @@
+package ALPM::File v1.0.0;
+
+use strict;
+use warnings;
+
+sub name { return $_[0]->{name}; }
+
+sub size { return $_[0]->{size}; }
+
+sub mode { return $_[0]->{mode}; }
+
+1;

--- a/lib/ALPM/FileConflict.pm
+++ b/lib/ALPM/FileConflict.pm
@@ -1,0 +1,18 @@
+package ALPM::FileConflict v1.0.0;
+
+use strict;
+use warnings;
+
+sub target { return $_[0]->{target}; }
+
+sub file { return $_[0]->{file}; }
+
+sub ctarget { return $_[0]->{ctarget}; }
+
+package ALPM::FileConflict::Target v1.0.0;
+use parent -norequire, 'ALPM::FileConflict';
+
+package ALPM::FileConflict::Filesystem v1.0.0;
+use parent -norequire, 'ALPM::FileConflict';
+
+1;

--- a/lib/ALPM/FileList.pm
+++ b/lib/ALPM/FileList.pm
@@ -1,0 +1,18 @@
+package ALPM::FileList v1.0.0;
+
+use strict;
+use warnings;
+
+use List::Util qw( first );
+
+sub files { return @{ $_[0] }; }
+
+sub count { return scalar @{ $_[0] }; }
+
+sub contains {
+	# FIXME: inefficient, switch to binary search or alpm_filelist_contains
+	my ( $self, $path ) = @_;
+	return first { $_ eq $path } @{$self};
+}
+
+1;

--- a/lib/ALPM/MissingDependency.pm
+++ b/lib/ALPM/MissingDependency.pm
@@ -1,0 +1,12 @@
+package ALPM::MissingDependency v1.0.0;
+
+use strict;
+use warnings;
+
+sub target { return $_[0]->{target}; }
+
+sub causingpkg { return $_[0]->{causingpkg}; }
+
+sub depend { return $_[0]->{depend}; }
+
+1;

--- a/typemap
+++ b/typemap
@@ -101,14 +101,14 @@ T_STROPT
 
 T_SETOPT
 	if($var == -1){
-		alpm_croak(self);
+		alpm_hthrow(self);
 	}else{
 		$arg = &PL_sv_yes;
 	}
 
 T_INTOPT
 	if($var == -1){
-		alpm_croak(self);
+		alpm_hthrow(self);
 	}else{
 		$arg = newSViv($var);
 	}

--- a/types.c
+++ b/types.c
@@ -10,6 +10,8 @@
 
 #include "types.h"
 
+#define BLESS(rv, class) sv_bless(rv, gv_stashpv(class, GV_ADD))
+
 /* SCALAR CONVERSIONS */
 
 SV*
@@ -105,7 +107,7 @@ c2p_depend(void *p)
 	hv_store(hv, "version", 7, newSVpv(dep->version, 0), 0);
 	hv_store(hv, "mod", 3, c2p_depmod(dep->mod), 0);
 	if(dep->desc) hv_store(hv, "desc", 4, newSVpv(dep->desc, 0), 0);
-	return newRV_noinc((SV*)hv);
+	return BLESS(newRV_noinc((SV*)hv), "ALPM::Dependency");
 }
 
 SV*
@@ -119,7 +121,7 @@ c2p_conflict(void *p)
 	hv_store(hv, "package1", 8, newSVpv(c->package1, 0), 0);
 	hv_store(hv, "package2", 8, newSVpv(c->package2, 0), 0);
 	hv_store(hv, "reason", 6, c2p_depend(c->reason), 0);
-	return newRV_noinc((SV*)hv);
+	return BLESS(newRV_noinc((SV*)hv), "ALPM::Conflict");
 }
 
 static SV*
@@ -129,7 +131,7 @@ c2p_file(alpm_file_t *file){
 	hv_store(hv, "name", 4, newSVpv(file->name, 0), 0);
 	hv_store(hv, "size", 4, newSViv(file->size), 0);
 	hv_store(hv, "mode", 4, newSViv(file->mode), 0);
-	return newRV_noinc((SV*)hv);
+	return BLESS(newRV_noinc((SV*)hv), "ALPM::File");
 }
 
 SV*
@@ -143,7 +145,7 @@ c2p_filelist(void *flistPtr){
 	for(i = 0; i < flist->count; i++){
 		av_push(av, c2p_file(flist->files + i));
 	}
-	return newRV_noinc((SV*)av);
+	return BLESS(newRV_noinc((SV*)av), "ALPM::Filelist");
 }
 
 /*

--- a/types.c
+++ b/types.c
@@ -134,6 +134,23 @@ c2p_conflict(void *p)
 	return BLESS(newRV_noinc((SV*)hv), "ALPM::Conflict");
 }
 
+SV*
+c2p_fileconflict(alpm_fileconflict_t *c)
+{
+	HV *hv = newHV();
+	char *class = "ALPM::FileConflict";
+	if(c->type == ALPM_FILECONFLICT_TARGET) {
+		class = "ALPM::FileConflict::Target";
+	} else if(c->type == ALPM_FILECONFLICT_FILESYSTEM) {
+		class = "ALPM::FileConflict::Filesystem";
+	}
+
+	hv_store(hv, "target", 6, newSVpv(c->target, 0), 0);
+	hv_store(hv, "file", 4, newSVpv(c->file, 0), 0);
+	hv_store(hv, "ctarget", 7, newSVpv(c->ctarget, 0), 0);
+	return BLESS(newRV_noinc((SV*)hv), class);
+}
+
 static SV*
 c2p_file(alpm_file_t *file){
 	HV *hv;

--- a/types.c
+++ b/types.c
@@ -393,18 +393,3 @@ av2list(AV *A, listmap F)
 	}
 	return L;
 }
-
-void
-freedepend(void *p)
-{
-	free((alpm_depend_t*)p);
-}
-
-void
-freeconflict(void *p)
-{
-	alpm_conflict_t *c;
-	c = p;
-	freedepend(c->reason);
-	free(c);
-}

--- a/types.c
+++ b/types.c
@@ -111,6 +111,16 @@ c2p_depend(void *p)
 }
 
 SV*
+c2p_depmissing(alpm_depmissing_t *dep)
+{
+	HV *hv = newHV();
+	hv_stores(hv, "target", newSVpvn(dep->target, strlen(dep->target)));
+	hv_stores(hv, "causingpkg", newSVpvn(dep->causingpkg, strlen(dep->causingpkg)));
+	hv_stores(hv, "depend", c2p_depend(dep->depend));
+	return BLESS(newRV_noinc((SV*)hv), "ALPM::MissingDependency");
+}
+
+SV*
 c2p_conflict(void *p)
 {
 	alpm_conflict_t *c;

--- a/types.h
+++ b/types.h
@@ -52,6 +52,7 @@ SV* c2p_depend(void *);
 SV* c2p_depmissing(alpm_depmissing_t *dep);
 SV* c2p_conflict(void *);
 SV* c2p_filelist(void *);
+SV* c2p_fileconflict(alpm_fileconflict_t *c);
 
 SV* c2p_siglevel(alpm_siglevel_t);
 alpm_siglevel_t p2c_siglevel(SV*);

--- a/types.h
+++ b/types.h
@@ -79,13 +79,8 @@ alpm_list_t* av2list(AV*, listmap);
 	}
 
 #define ZAPLIST(L, F)\
-	alpm_list_free_inner(L, F);\
+	alpm_list_free_inner(L, (alpm_list_fn_free) F);\
 	alpm_list_free(L);\
 	L = NULL
-
-/* MEMORY DEALLOCATION */
-
-void freedepend(void *);
-void freeconflict(void *);
 
 #endif /*_ALPMXS_TYPES */

--- a/types.h
+++ b/types.h
@@ -49,6 +49,7 @@ SV* c2p_localdb(void*);
 SV* c2p_syncdb(void*);
 SV* c2p_depmod(alpm_depmod_t);
 SV* c2p_depend(void *);
+SV* c2p_depmissing(alpm_depmissing_t *dep);
 SV* c2p_conflict(void *);
 SV* c2p_filelist(void *);
 

--- a/xs/Exception.xs
+++ b/xs/Exception.xs
@@ -1,0 +1,21 @@
+#include "exception.h"
+
+MODULE = ALPM      PACKAGE = ALPM::Exception
+
+BOOT:
+    register_eclasses();
+
+const char *
+alpm_strerror(err)
+        int err
+
+# /* define errno here to avoid symbolic ref in ALPM/Exception.pm */
+SV *
+errno(self)
+        SV * self
+    CODE:
+        HV *stash = sv_isobject(self) ? SvSTASH(SvRV(self)) : gv_stashsv(self, 0);
+        SV **val = hv_fetchs(stash, "errno", 0);
+        RETVAL = val == NULL ? &PL_sv_undef : newSVsv(GvSV(*val));
+    OUTPUT:
+        RETVAL

--- a/xs/Options.xs
+++ b/xs/Options.xs
@@ -268,7 +268,7 @@ syncdbs(self)
 	alpm_list_t *lst;
  PPCODE:
 	lst = alpm_get_syncdbs(self);
-	if(lst == NULL && alpm_errno(self)) alpm_croak(self);
+	if(lst == NULL && alpm_errno(self)) alpm_hthrow(self);
 	LIST2STACK(lst, c2p_syncdb);
 
 ALPM_SigLevel

--- a/xs/Transaction.xs
+++ b/xs/Transaction.xs
@@ -70,3 +70,9 @@ alpm_trans_interrupt(handle)
 		ALPM_Handle handle
 	POSTCALL:
 		if(RETVAL != 0) alpm_hthrow(handle);
+
+NO_OUTPUT int
+alpm_trans_release(handle)
+		ALPM_Handle handle
+	POSTCALL:
+		if(RETVAL != 0) alpm_hthrow(handle);

--- a/xs/Transaction.xs
+++ b/xs/Transaction.xs
@@ -1,0 +1,66 @@
+MODULE = ALPM	 PACKAGE = ALPM	PREFIX = alpm_
+
+#define hv_store_trans_flag(hash, key, arg, flag) \
+	hv_stores(hash, #key, newSViv((arg & flag) ? 1 : 0))
+#define hv_fetch_trans_flag(hash, key, var, flag) do { \
+	SV** val = hv_fetchs((HV*) SvRV(hash), #key, 0); \
+	if(val && SvTRUE(*val)) { var |= flag; } \
+} while(0)
+
+TYPEMAP: <<TMAP
+
+alpm_transflag_t ALPM_TRANSFLAG
+
+INPUT
+ALPM_TRANSFLAG
+	$var = 0;
+	hv_fetch_trans_flag($arg, alldeps, $var, ALPM_TRANS_FLAG_ALLDEPS);
+	hv_fetch_trans_flag($arg, allexplicit, $var, ALPM_TRANS_FLAG_ALLEXPLICIT);
+	hv_fetch_trans_flag($arg, cascade, $var, ALPM_TRANS_FLAG_CASCADE);
+	hv_fetch_trans_flag($arg, dbonly, $var, ALPM_TRANS_FLAG_DBONLY);
+	hv_fetch_trans_flag($arg, downloadonly, $var, ALPM_TRANS_FLAG_DOWNLOADONLY);
+	hv_fetch_trans_flag($arg, force, $var, ALPM_TRANS_FLAG_FORCE);
+	hv_fetch_trans_flag($arg, needed, $var, ALPM_TRANS_FLAG_NEEDED);
+	hv_fetch_trans_flag($arg, noconflicts, $var, ALPM_TRANS_FLAG_NOCONFLICTS);
+	hv_fetch_trans_flag($arg, nodeps, $var, ALPM_TRANS_FLAG_NODEPS);
+	hv_fetch_trans_flag($arg, nodepversion, $var, ALPM_TRANS_FLAG_NODEPVERSION);
+	hv_fetch_trans_flag($arg, nolock, $var, ALPM_TRANS_FLAG_NOLOCK);
+	hv_fetch_trans_flag($arg, nosave, $var, ALPM_TRANS_FLAG_NOSAVE);
+	hv_fetch_trans_flag($arg, noscriptlet, $var, ALPM_TRANS_FLAG_NOSCRIPTLET);
+	hv_fetch_trans_flag($arg, recurse, $var, ALPM_TRANS_FLAG_RECURSE);
+	hv_fetch_trans_flag($arg, recurseall, $var, ALPM_TRANS_FLAG_RECURSEALL);
+	hv_fetch_trans_flag($arg, unneeded, $var, ALPM_TRANS_FLAG_UNNEEDED);
+
+OUTPUT
+ALPM_TRANSFLAG
+	HV *hash = newHV();
+	hv_store_trans_flag(hash, alldeps, $var, ALPM_TRANS_FLAG_ALLDEPS);
+	hv_store_trans_flag(hash, allexplicit, $var, ALPM_TRANS_FLAG_ALLEXPLICIT);
+	hv_store_trans_flag(hash, cascade, $var, ALPM_TRANS_FLAG_CASCADE);
+	hv_store_trans_flag(hash, dbonly, $var, ALPM_TRANS_FLAG_DBONLY);
+	hv_store_trans_flag(hash, downloadonly, $var, ALPM_TRANS_FLAG_DOWNLOADONLY);
+	hv_store_trans_flag(hash, force, $var, ALPM_TRANS_FLAG_FORCE);
+	hv_store_trans_flag(hash, needed, $var, ALPM_TRANS_FLAG_NEEDED);
+	hv_store_trans_flag(hash, noconflicts, $var, ALPM_TRANS_FLAG_NOCONFLICTS);
+	hv_store_trans_flag(hash, nodeps, $var, ALPM_TRANS_FLAG_NODEPS);
+	hv_store_trans_flag(hash, nodepversion, $var, ALPM_TRANS_FLAG_NODEPVERSION);
+	hv_store_trans_flag(hash, nolock, $var, ALPM_TRANS_FLAG_NOLOCK);
+	hv_store_trans_flag(hash, nosave, $var, ALPM_TRANS_FLAG_NOSAVE);
+	hv_store_trans_flag(hash, noscriptlet, $var, ALPM_TRANS_FLAG_NOSCRIPTLET);
+	hv_store_trans_flag(hash, recurse, $var, ALPM_TRANS_FLAG_RECURSE);
+	hv_store_trans_flag(hash, recurseall, $var, ALPM_TRANS_FLAG_RECURSEALL);
+	hv_store_trans_flag(hash, unneeded, $var, ALPM_TRANS_FLAG_UNNEEDED);
+	sv_setsv($arg, newRV_noinc((SV*) hash));
+
+TMAP
+
+alpm_transflag_t
+alpm_trans_get_flags(handle)
+		ALPM_Handle handle
+
+NO_OUTPUT int
+alpm_trans_init(handle, flags=0)
+		ALPM_Handle handle
+		alpm_transflag_t flags
+	POSTCALL:
+		if(RETVAL != 0) alpm_hthrow(handle);

--- a/xs/Transaction.xs
+++ b/xs/Transaction.xs
@@ -76,3 +76,35 @@ alpm_trans_release(handle)
 		ALPM_Handle handle
 	POSTCALL:
 		if(RETVAL != 0) alpm_hthrow(handle);
+
+NO_OUTPUT int
+alpm_add_pkg(handle, pkg)
+		ALPM_Handle handle
+		ALPM_Package pkg
+	POSTCALL:
+		if(RETVAL != 0) alpm_hthrow(handle);
+
+NO_OUTPUT int
+alpm_remove_pkg(handle, pkg)
+		ALPM_Handle handle
+		ALPM_Package pkg
+	POSTCALL:
+		if(RETVAL != 0) alpm_hthrow(handle);
+
+void
+alpm_trans_get_add(handle)
+		ALPM_Handle handle
+	PREINIT:
+		alpm_list_t *l;
+	PPCODE:
+		l = alpm_trans_get_add(handle);
+		LIST2STACK(l, c2p_pkg);
+
+void
+alpm_trans_get_remove(handle)
+		ALPM_Handle handle
+	PREINIT:
+		alpm_list_t *l;
+	PPCODE:
+		l = alpm_trans_get_remove(handle);
+		LIST2STACK(l, c2p_pkg);

--- a/xs/Transaction.xs
+++ b/xs/Transaction.xs
@@ -64,3 +64,9 @@ alpm_trans_init(handle, flags=0)
 		alpm_transflag_t flags
 	POSTCALL:
 		if(RETVAL != 0) alpm_hthrow(handle);
+
+NO_OUTPUT int
+alpm_trans_interrupt(handle)
+		ALPM_Handle handle
+	POSTCALL:
+		if(RETVAL != 0) alpm_hthrow(handle);


### PR DESCRIPTION
Documentation and callback support are still missing, so this is not ready to be pulled yet.  An in-progress version of callback support is available on my callbacks branch, including a working example script to install/remove packages.  Note: the script uses my pacutils library for the config parsing: https://github.com/andrewgregory/pacutils (perl interface at: https://github.com/andrewgregory/perl-pacutils).
